### PR TITLE
Lee bergstrand add pyarrow

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -5,3 +5,4 @@ sqlalchemy==1.3.23
 Flask==1.1.2
 werkzeug==1.0.1
 flask-cors==3.0.10
+pyarrow>=1.0.1,<3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sqlalchemy==1.3.23
 Flask==1.1.2
 werkzeug==1.0.1
 flask-cors==3.0.10
+pyarrow>=1.0.1,<3.0.0


### PR DESCRIPTION
Pygenprop has issues installing pyarrow through pip given the unique state presented by the Docker environment generated by the Dockerfile. Install pyarrow via conda as part of micromeda server's installation to compensate.